### PR TITLE
Handle asynchonous reading of css files

### DIFF
--- a/html-css-class-completion/extension.js
+++ b/html-css-class-completion/extension.js
@@ -13,12 +13,17 @@ function activate(context) {
         vscode.workspace.findFiles('**/*.css', 'node_modules/**/node_modules/**/*').then(function (uris) {
             // will contain all the css files concatenated
             var cssFilesConcatenated = "";
+            // keeps track of how many css files have been concatenated
+            var numCssFilesConcatenated = 0;
             // goes through each css file found and open it
             uris.forEach(function (uri, index) {
                 vscode.workspace.openTextDocument(uri).then(function (textDocument) {
                     // extracts the text of the file and concatenates it
                     cssFilesConcatenated += textDocument.getText();
-                    if (uris.length == index + 1) {
+                    // Because openTextDocument() resolves asynchronously, it will frequently happen that the last file
+                    // in the uris array is finished loading before some of the previous files in the array.
+                    // We need to count how many files have been concatenated to know if we have all of them.
+                    if (uris.length == ++numCssFilesConcatenated) {
                         // after finishing the process the css classes are fetched from this large string and added to the classes array
                         fetchClasses(cssFilesConcatenated, classes);
                         vscode.window.showInformationMessage("HTML CSS Class Completion: Finished fetching CSS rules from CSS files.");


### PR DESCRIPTION
The extension uses `vscode.workspace.openTextDocument(uri)` to load the css files containing the classes that needs to be passed. This method runs asynchronously, while immediately returning a promise that resolves to the opened document which is then concatenated into one big css string.

Previously, the code used the index of the file returned from the `uris.forEach()` callback to find out if all the files had been concatenated. When the index was the same as the size of the uris array, the concatenated css was passed on to the css parser. However, since the files are opened asynchronously by openTextDocument(), the order in which the files are actually opened is more or less random. The result is that it is possible for the css parser to get called before you have finished reading all the css files in the workspace, meaning that a bunch of css classes will be missing from the class suggestions.

This pull request fixes that by counting how many files have been processed, instead of depending on the order in which they were opened.
