### PR TITLE
Single quote, double quote, and space triggers completion

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -10,6 +10,8 @@ import ParseEngineGateway from './parse-engine-gateway';
 let notifier: Notifier = new Notifier('html-css-class-completion.cache');
 let uniqueDefinitions: CssClassDefinition[];
 
+const completionTriggerChars = ['"', '\'', ' '];
+
 function cache(): Promise<void> {
     return new Promise<void>(async (resolve, reject): Promise<void> => {
         try {
@@ -98,7 +100,7 @@ function provideCompletionItemsGenerator(languageSelector: string, classMatchReg
 
             return completionItems;
         }
-    });
+    }, ...completionTriggerChars);
 }
 
 export async function activate(context: vscode.ExtensionContext): Promise<void> {


### PR DESCRIPTION
Due to the RegEx checks, it will only activate the completion dropdown when typing `className="|` or `class="|`, **not** `style="|` or `id="|`.

Use space to trigger autocompletion for when you're editing classes. 
Ex: `className="btn |` will open the menu.