### PR TITLE
Fixes #60, Supports Markdown Files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+### 1.7.0 (Jun 8, 2017)
+* Added support for Markdown
+
 ### 1.6.0 (Jun 4, 2017)
 * Added support for Twig.
 

--- a/README.md
+++ b/README.md
@@ -18,9 +18,13 @@ A Visual Studio Code extension that provides CSS class name completion for the H
 * TypeScript React (.tsx)
 * Vue (.vue) [requires [vetur](https://marketplace.visualstudio.com/items?itemName=octref.vetur)]
 * Twig
+* Markdown (.md)
 
 ## Contributions
 You can request new features and/or contribute to the extension development on its [repository on GitHub](https://github.com/Zignd/HTML-CSS-Class-Completion/issues).
+
+## What's new in version 1.7.0 (Jun 8, 2017)
+* Added support for Markdown
 
 ## What's new in version 1.6.0 (Jun 4, 2017)
 * Added support for Twig.

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "html-css-class-completion",
     "displayName": "IntelliSense for CSS class names",
     "description": "Provides CSS class name completion for the HTML class attribute based on the CSS files in your workspace. Also supports React's className attribute.",
-    "version": "1.6.0",
+    "version": "1.7.0",
     "publisher": "Zignd",
     "engines": {
         "vscode": "^1.4.0"

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -117,7 +117,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
     const php = provideCompletionItemsGenerator('php', htmlRegex);
     const vue = provideCompletionItemsGenerator('vue', htmlRegex);
     const twig = provideCompletionItemsGenerator('twig', htmlRegex);
-    const md = provideCompletionItemsGenerator('md', htmlRegex);
+    const md = provideCompletionItemsGenerator('markdown', htmlRegex);
     const tsReact = provideCompletionItemsGenerator('typescriptreact', jsxRegex);
     const js = provideCompletionItemsGenerator('javascript', jsxRegex)
     const jsReact = provideCompletionItemsGenerator('javascriptreact', jsxRegex);

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -117,6 +117,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
     const php = provideCompletionItemsGenerator('php', htmlRegex);
     const vue = provideCompletionItemsGenerator('vue', htmlRegex);
     const twig = provideCompletionItemsGenerator('twig', htmlRegex);
+    const md = provideCompletionItemsGenerator('md', htmlRegex);
     const tsReact = provideCompletionItemsGenerator('typescriptreact', jsxRegex);
     const js = provideCompletionItemsGenerator('javascript', jsxRegex)
     const jsReact = provideCompletionItemsGenerator('javascriptreact', jsxRegex);
@@ -126,6 +127,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
     context.subscriptions.push(php);
     context.subscriptions.push(vue);
     context.subscriptions.push(twig);
+    context.subscriptions.push(md);
     context.subscriptions.push(tsReact);
     context.subscriptions.push(js);
     context.subscriptions.push(jsReact);


### PR DESCRIPTION
Copying the changes necessary to support PHP files and the like, this simple PR extends support to Markdown files. This is extremely useful for Jekyll sites which mix HTMl inside markdown, along with other Liquid or similarly built frameworks.

Should be noted, similar functionality exists in rival extension HTML CSS Support, so it makes sense to add such support here.