### PR TITLE
Exclude npm_modules when fetching files to index

### DIFF
--- a/src/fetcher.ts
+++ b/src/fetcher.ts
@@ -5,7 +5,7 @@ class Fetcher {
     static async findAllParseableDocuments(): Promise<vscode.Uri[]> {
         const languages = ParseEngineRegistry.supportedLanguagesIds.join(',');
 
-        return await vscode.workspace.findFiles(`**/*.{${languages}}`, '');
+        return await vscode.workspace.findFiles(`**/*.{${languages}}`, '**/node_modules');
     }
 }
 


### PR DESCRIPTION
Hi, I'm a member of the VS Code team. In 1.17 we have unintentionally changed the behavior of `workspace.findFiles`. In 1.16 it was hard coded to exclude the node_modules from searching. In 1.17 this is no longer the case. Not excluding the node_modules folder can have a huge impact on startup performance in a large workspace. It will also result in polluting the problems view with many errors/warnings.

The PR changes the fetcher to explicitly exclude the node_modules. 