### PR TITLE
Fix for issue #85 Extension hangs / freezes VS Code in big folders

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -33,7 +33,7 @@ function cache(): Promise<void> {
             let failedLogsCount: number = 0;
 
             console.log('Parsing documents and looking for CSS class definitions...');
-            return async.each(uris, async (uri, callback) => {
+            return async.eachLimit(uris, 100, async (uri, callback) => {
                 try {
                     Array.prototype.push.apply(definitions, await ParseEngineGateway.callParser(uri));
                     callback();

--- a/src/parse-engine-gateway.ts
+++ b/src/parse-engine-gateway.ts
@@ -1,11 +1,36 @@
 import * as vscode from 'vscode';
+import * as fs from 'fs';
+
 import CssClassDefinition from './common/css-class-definition';
 import ParseEngine from './parse-engines/common/parse-engine';
+import SimpleTextDocument from './parse-engines/common/simple-textdocument';
 import ParseEngineRegistry from './parse-engines/parse-engine-registry';
+
+async function readFile(file: string): Promise<string> {
+	return new Promise<string>((resolve, reject) => {
+		fs.readFile(file, (err, data) => {
+			if (err) {
+				reject(err);
+			}
+			resolve(data.toString());
+		});
+	});
+}
+
+async function createSimpleTextDocument(uri:vscode.Uri): Promise<SimpleTextDocument> {
+    let text = await readFile(uri.fsPath);
+    let simpleDocument:SimpleTextDocument = {
+        languageId: uri.fsPath.split('.').pop(),
+        getText():string {
+            return text;
+        }
+    }
+    return simpleDocument;
+}
 
 class ParseEngineGateway {
     public static async callParser(uri: vscode.Uri): Promise<CssClassDefinition[]> {
-        let textDocument = await vscode.workspace.openTextDocument(uri);
+        let textDocument = await createSimpleTextDocument(uri);
         let parseEngine: ParseEngine = ParseEngineRegistry.getParseEngine(textDocument.languageId);
         let cssClassDefinitions: CssClassDefinition[] = await parseEngine.parse(textDocument);
         return cssClassDefinitions;

--- a/src/parse-engines/common/parse-engine.ts
+++ b/src/parse-engines/common/parse-engine.ts
@@ -1,10 +1,10 @@
-import * as vscode from 'vscode';
 import CssClassDefinition from './../../common/css-class-definition';
+import SimpleTextDocument from './simple-textdocument';
 
 interface ParseEngine {
     languageId: string;
     extension: string;
-    parse(textDocument: vscode.TextDocument): Promise<CssClassDefinition[]>;
+    parse(textDocument: SimpleTextDocument): Promise<CssClassDefinition[]>;
 }
 
 export default ParseEngine;

--- a/src/parse-engines/common/simple-textdocument.ts
+++ b/src/parse-engines/common/simple-textdocument.ts
@@ -1,0 +1,9 @@
+/**
+ * A minimum standin for vscode.TextDocument that is passed to a `ParseEngine`.
+ */
+interface SimpleTextDocument {
+    languageId:string;
+    getText():string;
+}
+
+export default SimpleTextDocument;

--- a/src/parse-engines/types/css-parse-engine.ts
+++ b/src/parse-engines/types/css-parse-engine.ts
@@ -2,13 +2,14 @@ import * as css from 'css';
 import * as vscode from 'vscode';
 import CssClassDefinition from '../../common/css-class-definition';
 import ParseEngine from '../common/parse-engine';
+import SimpleTextDocument from '../common/simple-textdocument';
 import CssClassExtractor from '../common/css-class-extractor';
 
 class CssParseEngine implements ParseEngine {
     public languageId: string = 'css';
     public extension: string = 'css';
 
-    public async parse(textDocument: vscode.TextDocument): Promise<CssClassDefinition[]> {
+    public async parse(textDocument: SimpleTextDocument): Promise<CssClassDefinition[]> {
         let code: string = textDocument.getText();
         let codeAst: css.Stylesheet = css.parse(code);
 

--- a/src/parse-engines/types/html-parse-engine.ts
+++ b/src/parse-engines/types/html-parse-engine.ts
@@ -6,12 +6,13 @@ import * as vscode from 'vscode';
 import CssClassDefinition from '../../common/css-class-definition';
 import CssClassExtractor from '../common/css-class-extractor';
 import ParseEngine from '../common/parse-engine';
+import SimpleTextDocument from '../common/simple-textdocument';
 
 class HtmlParseEngine implements ParseEngine {
     public languageId: string = 'html';
     public extension: string = 'html';
 
-    public parse(textDocument: vscode.TextDocument): Promise<CssClassDefinition[]> {
+    public parse(textDocument: SimpleTextDocument): Promise<CssClassDefinition[]> {
         return new Promise((resolve, reject) => {
             const definitions: CssClassDefinition[] = [];
             const urls: string[] = [];


### PR DESCRIPTION
This fix makes two changes:
- instead of parsing all files in parallel, it does it in batches by using the `async.eachLimit` function with a batch size of 100 (see the change in extension.ts).
- it replaces the use of `vscode.TextDocument` with a cheaper implementation that reads the file directly from disk using the node `fs` module. I did the change minimally invasive so that the parsers are only minimally affected.

Tested the scalability of the implementation of the chromium code base. The vscode UI was staying responsive and the extension host did not crash 😄. This is the result:
```
[Extension Host] Summary:
[Extension Host]% 46577 parseable documents found
[Extension Host]% 55894 CSS class definitions found
[Extension Host]% 9822 unique CSS class definitions found
[Extension Host]% 681 failed attempts to parse.
```
