### PR TITLE
Tailwind css support

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,9 @@ A Visual Studio Code extension that provides CSS class name completion for the H
 * Handlebars
 * EJS (.ejs)
 
+## Library Specific Support
+* @apply in CSS, SASS and SCSS Files for [Tailwind CSS](https://tailwindcss.com)
+
 ## Contributions
 You can request new features and/or contribute to the extension development on its [repository on GitHub](https://github.com/Zignd/HTML-CSS-Class-Completion/issues). Look for an issue you're interested in working on, comment on it to let me know you're working on it and submit your pull request! :D
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -135,7 +135,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
     // CSS based extensions
     ['css', 'sass', 'scss'].forEach((extension) => {
         // Support for Tailwind CSS
-        context.subscriptions.push(provideCompletionItemsGenerator(extension, /@apply ([\w- ]*$)/), true);
+        context.subscriptions.push(provideCompletionItemsGenerator(extension, /@apply ([\w- ]*$)/));
     });
 
     caching = true;

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -132,6 +132,12 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
         context.subscriptions.push(provideCompletionItemsGenerator(extension, /class=["|']([\w- ]*$)/));
     });
 
+    // CSS based extensions
+    ['css', 'sass', 'scss'].forEach((extension) => {
+        // Support for Tailwind CSS
+        context.subscriptions.push(provideCompletionItemsGenerator(extension, /@apply ([\w- ]*$)/), true);
+    });
+
     caching = true;
     try {
         await cache();


### PR DESCRIPTION
I was hoping we could merge in support for [Tailwind CSS](https://tailwindcss.com) which has some unique ways of applying styles and I think this would be a really useful addition. Tailwind is a new CSS Framework which uses custom CSS tags through PostCss. The `@apply` syntax is used to trigger the intellisense.