### PR TITLE
Glob patterns

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,10 @@ You can request new features and/or contribute to the extension development on i
 Check out the [change log](https://github.com/zignd/HTML-CSS-Class-Completion/blob/master/CHANGELOG.md) for the current and previous updates.
 
 ## Usage
-If there are HTML files on your workspace, the extension automatically starts and looks for CSS class definitions. In case new CSS classes are defined or new CSS files are added to the workspace and you also want auto completion for them, simply hit the lightning icon on the status bar and execute the command by pressing `Ctrl+Shift+P`(`cmd+Shift+P` for Mac) and then typing "Cache CSS class definitions".
+If there are HTML or JS files on your workspace, the extension automatically starts and looks for CSS class definitions. In case new CSS classes are defined or new CSS files are added to the workspace and you also want auto completion for them, simply hit the lightning icon on the status bar and execute the command by pressing `Ctrl+Shift+P`(`cmd+Shift+P` for Mac) and then typing "Cache CSS class definitions".
+
+You can omit or exclusively include the folders to search for by using these configurations:
+`css-class-completion.includeGlobPattern` or `css-class-completion.excludeGlobPattern`.
 
 ![](https://i.imgur.com/O7NjEUW.gif)
 ![](https://i.imgur.com/uyiXqMb.gif)

--- a/package.json
+++ b/package.json
@@ -27,6 +27,23 @@
         "command": "html-css-class-completion.cache",
         "title": "Cache CSS class definitions"
       }
+    ],
+    "configuration": [
+      {
+        "title": "CSS Class Completion",
+        "properties": {
+          "css-class-completion.includeGlobPattern": {
+            "type": "string",
+            "default": "**/*",
+            "description": "A glob pattern that defines the folders to search for. The glob pattern will be matched against the paths of resulting matches relative to their workspace."
+          },
+          "css-class-completion.excludeGlobPattern": {
+            "type": "string",
+            "default": "node_modules∕*",
+            "description": "A glob pattern that defines files and folders to exclude. The glob pattern will be matched against the file paths of resulting matches relative to their workspace."
+          }
+        }
+      }
     ]
   },
   "icon": "images/icon.png",

--- a/package.json
+++ b/package.json
@@ -34,12 +34,12 @@
         "properties": {
           "html-css-class-completion.includeGlobPattern": {
             "type": "string",
-            "default": "**/*",
-            "description": "A glob pattern that defines the folders to search for. The glob pattern will be matched against the paths of resulting matches relative to their workspace."
+            "default": "**/*.{css,html}",
+            "description": "A glob pattern that defines files and folders to search for. The glob pattern will be matched against the paths of resulting matches relative to their workspace."
           },
           "html-css-class-completion.excludeGlobPattern": {
             "type": "string",
-            "default": "node_modules∕*",
+            "default": "",
             "description": "A glob pattern that defines files and folders to exclude. The glob pattern will be matched against the file paths of resulting matches relative to their workspace."
           }
         }

--- a/package.json
+++ b/package.json
@@ -32,12 +32,12 @@
       {
         "title": "CSS Class Completion",
         "properties": {
-          "css-class-completion.includeGlobPattern": {
+          "html-css-class-completion.includeGlobPattern": {
             "type": "string",
             "default": "**/*",
             "description": "A glob pattern that defines the folders to search for. The glob pattern will be matched against the paths of resulting matches relative to their workspace."
           },
-          "css-class-completion.excludeGlobPattern": {
+          "html-css-class-completion.excludeGlobPattern": {
             "type": "string",
             "default": "node_modules∕*",
             "description": "A glob pattern that defines files and folders to exclude. The glob pattern will be matched against the file paths of resulting matches relative to their workspace."

--- a/src/fetcher.ts
+++ b/src/fetcher.ts
@@ -5,7 +5,10 @@ class Fetcher {
     static async findAllParseableDocuments(): Promise<vscode.Uri[]> {
         const languages = ParseEngineRegistry.supportedLanguagesIds.join(',');
 
-        return await vscode.workspace.findFiles(`**/*.{${languages}}`, '');
+        const includeGlobPattern = vscode.workspace.getConfiguration().get('css-class-completion.includeGlobPattern');
+        const excludeGlobPattern = vscode.workspace.getConfiguration().get('css-class-completion.excludeGlobPattern');
+
+        return await vscode.workspace.findFiles(`${includeGlobPattern}.{${languages}}`, `${excludeGlobPattern}`);
     }
 }
 

--- a/src/fetcher.ts
+++ b/src/fetcher.ts
@@ -5,8 +5,8 @@ class Fetcher {
     static async findAllParseableDocuments(): Promise<vscode.Uri[]> {
         const languages = ParseEngineRegistry.supportedLanguagesIds.join(',');
 
-        const includeGlobPattern = vscode.workspace.getConfiguration().get('css-class-completion.includeGlobPattern');
-        const excludeGlobPattern = vscode.workspace.getConfiguration().get('css-class-completion.excludeGlobPattern');
+        const includeGlobPattern = vscode.workspace.getConfiguration().get('html-css-class-completion.includeGlobPattern');
+        const excludeGlobPattern = vscode.workspace.getConfiguration().get('html-css-class-completion.excludeGlobPattern');
 
         return await vscode.workspace.findFiles(`${includeGlobPattern}.{${languages}}`, `${excludeGlobPattern}`);
     }

--- a/src/fetcher.ts
+++ b/src/fetcher.ts
@@ -3,12 +3,10 @@ import ParseEngineRegistry from './parse-engines/parse-engine-registry';
 
 class Fetcher {
     static async findAllParseableDocuments(): Promise<vscode.Uri[]> {
-        const languages = ParseEngineRegistry.supportedLanguagesIds.join(',');
-
         const includeGlobPattern = vscode.workspace.getConfiguration().get('html-css-class-completion.includeGlobPattern');
         const excludeGlobPattern = vscode.workspace.getConfiguration().get('html-css-class-completion.excludeGlobPattern');
 
-        return await vscode.workspace.findFiles(`${includeGlobPattern}.{${languages}}`, `${excludeGlobPattern}`);
+        return await vscode.workspace.findFiles(`${includeGlobPattern}`, `${excludeGlobPattern}`);
     }
 }
 


### PR DESCRIPTION
This will solve a lot of pending issues related to high cpu usage, crashes and the need to exclude some folders. Especially the node_modules folder that, how state in some comments, should be excluded by default.

The PR creates an config option to exclude and one to only include a path to parse.
They can defined as [Glob Patterns.](https://code.visualstudio.com/docs/extensionAPI/vscode-api#GlobPattern)

These are the issues that eventually can be closed:
#91 
#62 
maybe #64 ?
#47 
#31 
#27 
