### PR TITLE
support for "class" attribute in jsx

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -152,6 +152,7 @@ export async function activate(context: ExtensionContext): Promise<void> {
     // Javascript based extensions
     ['typescriptreact', 'javascript', 'javascriptreact'].forEach((extension) => {
         context.subscriptions.push(provideCompletionItemsGenerator(extension, /className=["|']([\w- ]*$)/));
+        context.subscriptions.push(provideCompletionItemsGenerator(extension, /class=["|']([\w- ]*$)/));
     });
 
     // HTML based extensions


### PR DESCRIPTION
A lot of jsx-compatible frameworks support traditional "class" attribute. I find the code much nicer when class is used instead of className.