### PR TITLE
Use activationevents to prevent launching the ext on unrelated workspaces

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,8 @@
     "Other"
   ],
   "activationEvents": [
-    "*"
+    "onLanguage:css",
+    "workspaceContains:**/*.css"
   ],
   "contributes": {
     "commands": [


### PR DESCRIPTION
fixes #116