### PR TITLE
Add autostart for EmmetCompletion

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -174,6 +174,11 @@ export async function activate(context: ExtensionContext): Promise<void> {
         }
     }));
 
+    // Enable Emmet Completion on startup if param is set to true
+    if (workspace.getConfiguration().get<boolean>("html-css-class-completion.enableEmmetSupport")) {
+        enableEmmetSupport(emmetDisposables);
+    }
+
     // Javascript based extensions
     ["typescriptreact", "javascript", "javascriptreact"].forEach((extension) => {
         context.subscriptions.push(provideCompletionItemsGenerator(extension, /className=["|']([\w- ]*$)/));


### PR DESCRIPTION
Actually EmmetActivation is only applied "onconfigurationchange", so after a VSCODE reboot the Emmet completion didn't work, except to change again parameter to false, and then to true.

This is for applying autocompletion on Emmet at startup if param is set to true.