### PR TITLE
Add support for autocompletion in postcss files

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -186,7 +186,7 @@ export async function activate(context: ExtensionContext): Promise<void> {
     });
 
     // CSS based extensions
-    ["css", "sass", "scss"].forEach((extension) => {
+    ["css", "sass", "scss", "postcss"].forEach((extension) => {
         // Support for Tailwind CSS
         context.subscriptions.push(provideCompletionItemsGenerator(extension, /@apply ([\.\w- ]*$)/, "."));
     });


### PR DESCRIPTION
I, and I presume others too, use postcss mode for sailwind css files, with language support via [PostCSS syntax](https://marketplace.visualstudio.com/items?itemName=ricard.PostCSS). This adds autocompletion for tailwind classes in postcss files (#131).