### PR TITLE
Added django-html to supported language modes

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ A Visual Studio Code extension that provides CSS class name completion for the H
 * Embedded Ruby (.html.erb) [requires [rebornix.Ruby](https://marketplace.visualstudio.com/items?itemName=rebornix.Ruby)]
 * Handlebars
 * EJS (.ejs)
+* Django Templates
 
 ## Specific Support
 * "@apply" directive in CSS, SASS and SCSS Files for [Tailwind CSS](https://tailwindcss.com)

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -122,7 +122,7 @@ function provideCompletionItemsGenerator(languageSelector: string, classMatchReg
 
 function enableEmmetSupport(disposables: Disposable[]) {
     const emmetRegex = /(?=\.)([\w-\. ]*$)/;
-    const languageModes = ["html", "razor", "php", "blade", "vue", "twig", "markdown", "erb",
+    const languageModes = ["html", "django-html", "razor", "php", "blade", "vue", "twig", "markdown", "erb",
         "handlebars", "ejs", "typescriptreact", "javascript", "javascriptreact"];
     languageModes.forEach((language) => {
         emmetDisposables.push(provideCompletionItemsGenerator(language, emmetRegex, "", "."));
@@ -181,7 +181,7 @@ export async function activate(context: ExtensionContext): Promise<void> {
     });
 
     // HTML based extensions
-    ["html", "razor", "php", "blade", "vue", "twig", "markdown", "erb", "handlebars", "ejs"].forEach((extension) => {
+    ["html", "django-html", "razor", "php", "blade", "vue", "twig", "markdown", "erb", "handlebars", "ejs"].forEach((extension) => {
         context.subscriptions.push(provideCompletionItemsGenerator(extension, /class=["|']([\w- ]*$)/));
     });
 


### PR DESCRIPTION
Extensions which add syntax highlighting to Django templates change the language mode to "django-html and, therefore, remove support by this extension; simple fix, I think.