### PR TITLE
take advantage of the activationEvents

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,8 @@
     "Other"
   ],
   "activationEvents": [
-    "*"
+    "onLanguage:html",
+		"onLanguage:css"
   ],
   "contributes": {
     "commands": [


### PR DESCRIPTION
It can take quite a while for this extensions to rev-up in larger repositories, so tight activationEvents are a must.  It's especially frustrating when there isn't a css file to be found anywhere in the repository.

If you absolutely must, you could also use "workspaceContains:**/*.{css,html}".

*sorry about the whitespace thing, I used the online editor and hit a snag*