### PR TITLE
Add support for aspnetcorerazor filetypes

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ A Visual Studio Code extension that provides CSS class name completion for the H
 
 ## Supported Language Modes
 * HTML
-* Razor
+* Razor [or aspnetcorerazor with [vscode.csharp](https://marketplace.visualstudio.com/items?itemName=ms-vscode.csharp)]
 * PHP
 * Laravel (Blade)
 * JavaScript
@@ -56,7 +56,7 @@ You can change the folders and files the extension will consider or exclude duri
 
 Emmet support comes disabled by default, the reason behind this choice is because it the current implementation simply triggers completion when you type a "." (period) and this behavior might be considered a little annoying, but it might change in the future.
 
-Currently it supports the following languages (those are [language identifier](https://code.visualstudio.com/docs/languages/identifiers#_known-language-identifiers)): "html", "razor", "php", "blade", "vue", "twig", "markdown", "erb", "handlebars", "ejs", "typescriptreact", "javascript", "javascriptreact".
+Currently it supports the following languages (those are [language identifier](https://code.visualstudio.com/docs/languages/identifiers#_known-language-identifiers)): "html", "razor", "aspnetcorerazor", "php", "blade", "vue", "twig", "markdown", "erb", "handlebars", "ejs", "typescriptreact", "javascript", "javascriptreact".
 
 * `"html-css-class-completion.enableEmmetSupport"` (default: `false`)
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -122,7 +122,7 @@ function provideCompletionItemsGenerator(languageSelector: string, classMatchReg
 
 function enableEmmetSupport(disposables: Disposable[]) {
     const emmetRegex = /(?=\.)([\w-\. ]*$)/;
-    const languageModes = ["html", "django-html", "razor", "php", "blade", "vue", "twig", "markdown", "erb",
+    const languageModes = ["html", "django-html", "razor", "aspnetcorerazor", "php", "blade", "vue", "twig", "markdown", "erb",
         "handlebars", "ejs", "typescriptreact", "javascript", "javascriptreact"];
     languageModes.forEach((language) => {
         emmetDisposables.push(provideCompletionItemsGenerator(language, emmetRegex, "", "."));
@@ -181,7 +181,7 @@ export async function activate(context: ExtensionContext): Promise<void> {
     });
 
     // HTML based extensions
-    ["html", "django-html", "razor", "php", "blade", "vue", "twig", "markdown", "erb", "handlebars", "ejs"].forEach((extension) => {
+    ["html", "django-html", "razor", "aspnetcorerazor", "php", "blade", "vue", "twig", "markdown", "erb", "handlebars", "ejs"].forEach((extension) => {
         context.subscriptions.push(provideCompletionItemsGenerator(extension, /class=["|']([\w- ]*$)/));
     });
 


### PR DESCRIPTION
If you are using Microsoft's [C# plugin](https://marketplace.visualstudio.com/items?itemName=ms-vscode.csharp) it changes `Razor` filetypes to be called `aspnetcorerazor` with some enhanced support. The files are the same, but the type name is different, so I've added that type as well. I've tested locally and it seems to work just as expected.