### PR TITLE
Switch parser to PostCSS to support additional syntax in CSS files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 dist
 node_modules
 *.vsix
+out

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,10 +1,13 @@
 // Place your settings in this file to overwrite default and user settings.
 {
-    "files.exclude": {
-        "out": false // set this to true to hide the "out" folder with the compiled JS files
-    },
-    "search.exclude": {
-        "out": true // set this to false to include "out" folder in search results
-    },
-    "typescript.tsdk": "./node_modules/typescript/lib" // we want to use the TS server from our node_modules folder to control its version
+  "files.exclude": {
+    "out": false // set this to true to hide the "out" folder with the compiled JS files
+  },
+  "search.exclude": {
+    "out": true // set this to false to include "out" folder in search results
+  },
+  "typescript.tsdk": "./node_modules/typescript/lib", // we want to use the TS server from our node_modules folder to control its version
+  "[typescript]": {
+    "editor.defaultFormatter": "vscode.typescript-language-features"
+  }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -272,7 +272,8 @@
     "atob": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/atob/-/atob-2.1.2.tgz",
-      "integrity": "sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg=="
+      "integrity": "sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg==",
+      "dev": true
     },
     "aws-sign2": {
       "version": "0.7.0",
@@ -699,7 +700,6 @@
       "version": "1.9.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.1.tgz",
       "integrity": "sha512-mjGanIiwQJskCC18rPR6OmrZ6fm2Lc7PeGFYwCmy5J34wC6F1PzdGL6xeMfmgicfYcNLGuVFA3WzXtIDCQSZxQ==",
-      "dev": true,
       "requires": {
         "color-name": "^1.1.1"
       }
@@ -707,8 +707,7 @@
     "color-name": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
-      "dev": true
+      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
     },
     "combined-stream": {
       "version": "1.0.7",
@@ -781,17 +780,6 @@
         "subarg": "^1.0.0"
       }
     },
-    "css": {
-      "version": "2.2.4",
-      "resolved": "https://registry.npmjs.org/css/-/css-2.2.4.tgz",
-      "integrity": "sha512-oUnjmWpy0niI3x/mPL8dVEI1l7MnG3+HHyRPHf+YFSbK+svOhXpmSOcDURUh2aOCgl2grzrOPt1nHLuCVFULLw==",
-      "requires": {
-        "inherits": "^2.0.3",
-        "source-map": "^0.6.1",
-        "source-map-resolve": "^0.5.2",
-        "urix": "^0.1.0"
-      }
-    },
     "css-select": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/css-select/-/css-select-1.2.0.tgz",
@@ -842,7 +830,8 @@
     "decode-uri-component": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.0.tgz",
-      "integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU="
+      "integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU=",
+      "dev": true
     },
     "deep-assign": {
       "version": "1.0.0",
@@ -1014,8 +1003,7 @@
     "escape-string-regexp": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
-      "dev": true
+      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
     },
     "esprima": {
       "version": "4.0.1",
@@ -3141,6 +3129,59 @@
       "integrity": "sha1-AerA/jta9xoqbAL+q7jB/vfgDqs=",
       "dev": true
     },
+    "postcss": {
+      "version": "7.0.32",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.32.tgz",
+      "integrity": "sha512-03eXong5NLnNCD05xscnGKGDZ98CyzoqPSMjOe6SuoQY7Z2hIj0Ld1g/O/UQRuOle2aRtiIRDg9tDcTGAkLfKw==",
+      "requires": {
+        "chalk": "^2.4.2",
+        "source-map": "^0.6.1",
+        "supports-color": "^6.1.0"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+          "requires": {
+            "color-convert": "^1.9.0"
+          }
+        },
+        "chalk": {
+          "version": "2.4.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+          "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+          "requires": {
+            "ansi-styles": "^3.2.1",
+            "escape-string-regexp": "^1.0.5",
+            "supports-color": "^5.3.0"
+          },
+          "dependencies": {
+            "supports-color": {
+              "version": "5.5.0",
+              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+              "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+              "requires": {
+                "has-flag": "^3.0.0"
+              }
+            }
+          }
+        },
+        "has-flag": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+          "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
+        },
+        "supports-color": {
+          "version": "6.1.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
+          "integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
+          "requires": {
+            "has-flag": "^3.0.0"
+          }
+        }
+      }
+    },
     "preserve": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/preserve/-/preserve-0.2.0.tgz",
@@ -3748,7 +3789,8 @@
     "resolve-url": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/resolve-url/-/resolve-url-0.2.1.tgz",
-      "integrity": "sha1-LGN/53yJOv0qZj/iGqkIAGjiBSo="
+      "integrity": "sha1-LGN/53yJOv0qZj/iGqkIAGjiBSo=",
+      "dev": true
     },
     "ret": {
       "version": "0.1.15",
@@ -3984,6 +4026,7 @@
       "version": "0.5.2",
       "resolved": "https://registry.npmjs.org/source-map-resolve/-/source-map-resolve-0.5.2.tgz",
       "integrity": "sha512-MjqsvNwyz1s0k81Goz/9vRBe9SZdB09Bdw+/zYyO+3CuPk6fouTaxscHkgtE8jKvf01kVfl8riHzERQ/kefaSA==",
+      "dev": true,
       "requires": {
         "atob": "^2.1.1",
         "decode-uri-component": "^0.2.0",
@@ -4010,7 +4053,8 @@
     "source-map-url": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/source-map-url/-/source-map-url-0.4.0.tgz",
-      "integrity": "sha1-PpNdfd1zYxuXZZlW1VEo6HtQhKM="
+      "integrity": "sha1-PpNdfd1zYxuXZZlW1VEo6HtQhKM=",
+      "dev": true
     },
     "split": {
       "version": "0.3.3",
@@ -4612,7 +4656,8 @@
     "urix": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/urix/-/urix-0.1.0.tgz",
-      "integrity": "sha1-2pN/emLiH+wf0Y1Js1wpNQZ6bHI="
+      "integrity": "sha1-2pN/emLiH+wf0Y1Js1wpNQZ6bHI=",
+      "dev": true
     },
     "url-join": {
       "version": "1.1.0",

--- a/package.json
+++ b/package.json
@@ -81,9 +81,9 @@
   },
   "dependencies": {
     "bluebird": "^3.5.1",
-    "css": "^2.2.4",
     "htmlparser2": "^3.9.2",
     "lodash": "^4.17.11",
+    "postcss": "^7.0.32",
     "request": "^2.88.0",
     "request-promise": "^4.2.1",
     "source-map-support": "^0.5.3",

--- a/src/parse-engines/common/css-class-extractor.ts
+++ b/src/parse-engines/common/css-class-extractor.ts
@@ -1,28 +1,25 @@
-import * as css from "css";
+import * as postcss from 'postcss';
 import CssClassDefinition from "../../common/css-class-definition";
 
 export default class CssClassExtractor {
     /**
      * @description Extracts class names from CSS AST
      */
-    public static extract(ast: css.Stylesheet): CssClassDefinition[] {
+    public static extract(ast: postcss.Root): CssClassDefinition[] {
         const classNameRegex: RegExp = /[.]([\w-]+)/g;
 
         const definitions: CssClassDefinition[] = [];
 
         // go through each of the rules...
-        ast.stylesheet.rules.forEach((rule: css.Rule) => {
-            // ...of type rule
-            if (rule.type === "rule") {
-                // go through each of the selectors of the current rule
-                rule.selectors.forEach((selector: string) => {
-                    let item: RegExpExecArray = classNameRegex.exec(selector);
-                    while (item) {
-                        definitions.push(new CssClassDefinition(item[1]));
-                        item = classNameRegex.exec(selector);
-                    }
-                });
-            }
+        ast.walkRules((rule) => {
+            // go through each of the selectors of the current rule
+            rule.selectors.forEach((selector) => {
+                let item: RegExpExecArray = classNameRegex.exec(selector);
+                while (item) {
+                    definitions.push(new CssClassDefinition(item[1]));
+                    item = classNameRegex.exec(selector);
+                }
+            });
         });
 
         return definitions;

--- a/src/parse-engines/types/css-parse-engine.ts
+++ b/src/parse-engines/types/css-parse-engine.ts
@@ -1,5 +1,4 @@
-import * as css from "css";
-import * as vscode from "vscode";
+import * as postcss from 'postcss';
 import CssClassDefinition from "../../common/css-class-definition";
 import CssClassExtractor from "../common/css-class-extractor";
 import IParseEngine from "../common/parse-engine";
@@ -11,9 +10,9 @@ class CssParseEngine implements IParseEngine {
 
     public async parse(textDocument: ISimpleTextDocument): Promise<CssClassDefinition[]> {
         const code: string = textDocument.getText();
-        const codeAst: css.Stylesheet = css.parse(code);
-
-        return CssClassExtractor.extract(codeAst);
+        const result = await postcss().process(code);
+        if (!result.root) return [];
+        return CssClassExtractor.extract(result.root);
     }
 }
 

--- a/src/parse-engines/types/html-parse-engine.ts
+++ b/src/parse-engines/types/html-parse-engine.ts
@@ -1,8 +1,7 @@
 import * as Bluebird from "bluebird";
-import * as css from "css";
 import * as html from "htmlparser2";
+import * as postcss from 'postcss';
 import * as request from "request-promise";
-import * as vscode from "vscode";
 import CssClassDefinition from "../../common/css-class-definition";
 import CssClassExtractor from "../common/css-class-extractor";
 import IParseEngine from "../common/parse-engine";
@@ -42,7 +41,7 @@ class HtmlParseEngine implements IParseEngine {
             },
             ontext: (text: string) => {
                 if (tag === "style") {
-                    definitions.push(...CssClassExtractor.extract(css.parse(text)));
+                    definitions.push(...CssClassExtractor.extract(postcss().process(text).root));
                 }
             },
         });
@@ -52,7 +51,7 @@ class HtmlParseEngine implements IParseEngine {
 
         await Bluebird.map(urls, async (url) => {
             const content = await request.get(url);
-            definitions.push(...CssClassExtractor.extract(css.parse(content)));
+            definitions.push(...CssClassExtractor.extract(postcss().process(content).root));
         }, { concurrency: 10 });
 
         return definitions;

--- a/src/parse-engines/types/html-parse-engine.ts
+++ b/src/parse-engines/types/html-parse-engine.ts
@@ -41,6 +41,7 @@ class HtmlParseEngine implements IParseEngine {
             },
             ontext: (text: string) => {
                 if (tag === "style") {
+                    // this should probably be async... not sure how to do that?
                     definitions.push(...CssClassExtractor.extract(postcss().process(text).root));
                 }
             },
@@ -51,7 +52,8 @@ class HtmlParseEngine implements IParseEngine {
 
         await Bluebird.map(urls, async (url) => {
             const content = await request.get(url);
-            definitions.push(...CssClassExtractor.extract(postcss().process(content).root));
+            const postcssResult = await postcss().process(content);
+            definitions.push(...CssClassExtractor.extract(postcssResult.root));
         }, { concurrency: 10 });
 
         return definitions;


### PR DESCRIPTION
Previously, the extension failed to pick up classes from files that used non-standard CSS syntax, such as `@apply` from tailwind. This PR changes the extension to use PostCSS as the parser instead.

This is pretty quick and dirty, and I only changed enough to get it working for my use case. I'm open to additional changes if needed