### PR TITLE
Allow escaped characters in css selectors

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -141,25 +141,25 @@ const registerHTMLProviders = (disposables: Disposable[]) =>
     workspace.getConfiguration()
         ?.get<string[]>(Configuration.HTMLLanguages)
         ?.forEach((extension) => {
-            disposables.push(registerCompletionProvider(extension, /class=["|']([\w- ]*$)/));
+            disposables.push(registerCompletionProvider(extension, /class=["|']([\w-@:\/ ]*$)/));
         });
 
-const registerCSSProviders = (disposables: Disposable[]) =>
+const registerCSSProviders = (disposables: Disposable[]) => 
     workspace.getConfiguration()
         .get<string[]>(Configuration.CSSLanguages)
         ?.forEach((extension) => {
             // The @apply rule was a CSS proposal which has since been abandoned,
             // check the proposal for more info: http://tabatkins.github.io/specs/css-apply-rule/
             // Its support should probably be removed
-            disposables.push(registerCompletionProvider(extension, /@apply ([.\w- ]*$)/, "."));
+            disposables.push(registerCompletionProvider(extension, /@apply ([.\w-@:\/ ]*$)/, "."));
         });
 
 const registerJavaScriptProviders = (disposables: Disposable[]) =>
     workspace.getConfiguration()
         .get<string[]>(Configuration.JavaScriptLanguages)
         ?.forEach((extension) => {
-            disposables.push(registerCompletionProvider(extension, /className=["|']([\w- ]*$)/));
-            disposables.push(registerCompletionProvider(extension, /class=["|']([\w- ]*$)/));
+            disposables.push(registerCompletionProvider(extension, /className=["|']([\w-@:\/ ]*$)/));
+            disposables.push(registerCompletionProvider(extension, /class=["|']([\w-@:\/ ]*$)/));
         });
 
 function registerEmmetProviders(disposables: Disposable[]) {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -163,7 +163,7 @@ const registerJavaScriptProviders = (disposables: Disposable[]) =>
         });
 
 function registerEmmetProviders(disposables: Disposable[]) {
-    const emmetRegex = /(?=\.)([\w-. ]*$)/;
+    const emmetRegex = /(?=\.)([\w-@:\/. ]*$)/;
 
     const registerProviders = (modes: string[]) => {
         modes.forEach((language) => {

--- a/src/parse-engines/common/css-class-extractor.ts
+++ b/src/parse-engines/common/css-class-extractor.ts
@@ -6,7 +6,7 @@ export default class CssClassExtractor {
      * @description Extracts class names from CSS AST
      */
     public static extract(ast: css.Stylesheet): CssClassDefinition[] {
-        const classNameRegex = /[.]([\w-]+)/g;
+        const classNameRegex = /[.]([\w-\\@\\:\\/]+)/g;
 
         const definitions: CssClassDefinition[] = [];
 
@@ -15,7 +15,7 @@ export default class CssClassExtractor {
             rule.selectors?.forEach((selector: string) => {
                 let item: RegExpExecArray | null = classNameRegex.exec(selector);
                 while (item) {
-                    definitions.push(new CssClassDefinition(item[1]));
+                    definitions.push(new CssClassDefinition(item[1].replace("\\", "")));
                     item = classNameRegex.exec(selector);
                 }
             });

--- a/src/parse-engines/common/css-class-extractor.ts
+++ b/src/parse-engines/common/css-class-extractor.ts
@@ -6,7 +6,7 @@ export default class CssClassExtractor {
      * @description Extracts class names from CSS AST
      */
     public static extract(ast: css.Stylesheet): CssClassDefinition[] {
-        const classNameRegex = /[.]([\w-\\@\\:\\/]+)/g;
+        const classNameRegex = /[.](([\w-]|\\[@:/])+)/g;
 
         const definitions: CssClassDefinition[] = [];
 


### PR DESCRIPTION
Fixes autocomplete for css selectors with escaped characters as described here #288.
Currently only supporting the following escaped characters: `\/`, `\@`, `\:`

Fixes #288