### PR TITLE
Add slim and HAML support

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,7 +62,17 @@
               "markdown",
               "erb",
               "ejs",
-              "svelte"
+              "svelte",
+              "haml",
+              "slim"
+            ]
+          },
+          "html-css-class-completion.HAMLLanguages": {
+            "type": "array",
+            "description": "A list of HAML based languages where suggestions are enabled.",
+            "default": [
+              "haml",
+              "slim"
             ]
           },
           "html-css-class-completion.CSSLanguages": {

--- a/package.json
+++ b/package.json
@@ -75,6 +75,15 @@
               "slim"
             ]
           },
+          "html-css-class-completion.ERBLanguages": {
+            "type": "array",
+            "description": "A list of ERB based languages where suggestions are enabled.",
+            "default": [
+              "erb",
+              "haml",
+              "slim"
+            ]
+          },
           "html-css-class-completion.CSSLanguages": {
             "type": "array",
             "description": "A list of CSS based languages where suggestions are enabled.",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -22,6 +22,7 @@ enum Configuration {
     EnableEmmetSupport = "html-css-class-completion.enableEmmetSupport",
     HTMLLanguages = "html-css-class-completion.HTMLLanguages",
     HAMLLanguages = "html-css-class-completion.HAMLLanguages",
+    ERBLanguages = "html-css-class-completion.ERBLanguages",
     CSSLanguages = "html-css-class-completion.CSSLanguages",
     JavaScriptLanguages = "html-css-class-completion.JavaScriptLanguages",
 }
@@ -35,6 +36,7 @@ let caching = false;
 
 const htmlDisposables: Disposable[] = [];
 const hamlDisposables: Disposable[] = [];
+const erbDisposables: Disposable[] = [];
 const cssDisposables: Disposable[] = [];
 const javaScriptDisposables: Disposable[] = [];
 const emmetDisposables: Disposable[] = [];
@@ -153,6 +155,13 @@ const registerHAMLProviders = (disposables: Disposable[]) =>
             disposables.push(registerCompletionProvider(extension, /(?=\.)([\w-. ]*$)/, "", "."));
         });
 
+const registerERBProviders = (disposables: Disposable[]) =>
+    workspace.getConfiguration()
+        ?.get<string[]>(Configuration.HAMLLanguages)
+        ?.forEach((extension) => {
+            disposables.push(registerCompletionProvider(extension, /class:\s+["|']([\w- ]*$)/));
+        });
+
 const registerCSSProviders = (disposables: Disposable[]) =>
     workspace.getConfiguration()
         .get<string[]>(Configuration.CSSLanguages)
@@ -221,6 +230,11 @@ export async function activate(context: ExtensionContext): Promise<void> {
                 registerHAMLProviders(hamlDisposables);
             }
 
+            if (e.affectsConfiguration(Configuration.ERBLanguages)) {
+                unregisterProviders(erbDisposables);
+                registerERBProviders(erbDisposables);
+            }
+
             if (e.affectsConfiguration(Configuration.CSSLanguages)) {
                 unregisterProviders(cssDisposables);
                 registerCSSProviders(cssDisposables);
@@ -261,6 +275,7 @@ export async function activate(context: ExtensionContext): Promise<void> {
 
     registerHTMLProviders(htmlDisposables);
     registerHAMLProviders(hamlDisposables);
+    registerERBProviders(erbDisposables);
     registerCSSProviders(cssDisposables);
     registerJavaScriptProviders(javaScriptDisposables);
 
@@ -279,6 +294,7 @@ export async function activate(context: ExtensionContext): Promise<void> {
 export function deactivate(): void {
     unregisterProviders(htmlDisposables);
     unregisterProviders(hamlDisposables);
+    unregisterProviders(erbDisposables);
     unregisterProviders(cssDisposables);
     unregisterProviders(javaScriptDisposables);
     unregisterProviders(emmetDisposables);

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -21,6 +21,7 @@ enum Configuration {
     ExcludeGlobPattern = "html-css-class-completion.excludeGlobPattern",
     EnableEmmetSupport = "html-css-class-completion.enableEmmetSupport",
     HTMLLanguages = "html-css-class-completion.HTMLLanguages",
+    HAMLLanguages = "html-css-class-completion.HAMLLanguages",
     CSSLanguages = "html-css-class-completion.CSSLanguages",
     JavaScriptLanguages = "html-css-class-completion.JavaScriptLanguages",
 }
@@ -33,6 +34,7 @@ const completionTriggerChars = ['"', "'", " ", "."];
 let caching = false;
 
 const htmlDisposables: Disposable[] = [];
+const hamlDisposables: Disposable[] = [];
 const cssDisposables: Disposable[] = [];
 const javaScriptDisposables: Disposable[] = [];
 const emmetDisposables: Disposable[] = [];
@@ -144,6 +146,13 @@ const registerHTMLProviders = (disposables: Disposable[]) =>
             disposables.push(registerCompletionProvider(extension, /class=["|']([\w- ]*$)/));
         });
 
+const registerHAMLProviders = (disposables: Disposable[]) =>
+    workspace.getConfiguration()
+        ?.get<string[]>(Configuration.HAMLLanguages)
+        ?.forEach((extension) => {
+            disposables.push(registerCompletionProvider(extension, /(?=\.)([\w-. ]*$)/, "", "."));
+        });
+
 const registerCSSProviders = (disposables: Disposable[]) =>
     workspace.getConfiguration()
         .get<string[]>(Configuration.CSSLanguages)
@@ -207,6 +216,11 @@ export async function activate(context: ExtensionContext): Promise<void> {
                 registerHTMLProviders(htmlDisposables);
             }
 
+            if (e.affectsConfiguration(Configuration.HAMLLanguages)) {
+                unregisterProviders(hamlDisposables);
+                registerHAMLProviders(hamlDisposables);
+            }
+
             if (e.affectsConfiguration(Configuration.CSSLanguages)) {
                 unregisterProviders(cssDisposables);
                 registerCSSProviders(cssDisposables);
@@ -246,6 +260,7 @@ export async function activate(context: ExtensionContext): Promise<void> {
     }
 
     registerHTMLProviders(htmlDisposables);
+    registerHAMLProviders(hamlDisposables);
     registerCSSProviders(cssDisposables);
     registerJavaScriptProviders(javaScriptDisposables);
 
@@ -263,6 +278,7 @@ export async function activate(context: ExtensionContext): Promise<void> {
 
 export function deactivate(): void {
     unregisterProviders(htmlDisposables);
+    unregisterProviders(hamlDisposables);
     unregisterProviders(cssDisposables);
     unregisterProviders(javaScriptDisposables);
     unregisterProviders(emmetDisposables);


### PR DESCRIPTION
Fixes #141 

I also extended erb support to include `class:` params, which is used in [`content_for`](https://api.rubyonrails.org/classes/ActionView/Helpers/TagHelper.html#method-i-content_tag) and a lot of methods that call that method, as well as any helper method someone might write that takes in a class name as a parameter.