### PR TITLE
Disable auto completion for emmet expressions inside comments

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -142,9 +142,6 @@ const registerHTMLProviders = (disposables: Disposable[]) =>
         ?.get<string[]>(Configuration.HTMLLanguages)
         ?.forEach((extension) => {
             disposables.push(registerCompletionProvider(extension, /class=["|']([\w- ]*$)/));
-
-            // Support for angular's routerLink
-            disposables.push(registerCompletionProvider(extension, /routerLinkActive=["|']([\w- ]*$)/));
         });
 
 const registerCSSProviders = (disposables: Disposable[]) =>

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -142,6 +142,9 @@ const registerHTMLProviders = (disposables: Disposable[]) =>
         ?.get<string[]>(Configuration.HTMLLanguages)
         ?.forEach((extension) => {
             disposables.push(registerCompletionProvider(extension, /class=["|']([\w- ]*$)/));
+
+            // Support for angular's routerLink
+            disposables.push(registerCompletionProvider(extension, /routerLinkActive=["|']([\w- ]*$)/));
         });
 
 const registerCSSProviders = (disposables: Disposable[]) =>

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -166,7 +166,7 @@ const registerJavaScriptProviders = (disposables: Disposable[]) =>
         });
 
 function registerEmmetProviders(disposables: Disposable[]) {
-    const emmetRegex = /(?=\.)([\w-. ]*$)/;
+    const emmetRegex = /^(?!\/{2}).*(?=\.)([\w-. ]*)$/;
 
     const registerProviders = (modes: string[]) => {
         modes.forEach((language) => {


### PR DESCRIPTION
Fixes a bug where the extension processes auto-completion inside of comments when performing an emmet expression.

fixes #344 