### PR TITLE
Add curly bracket to JS provider for use in React.

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -158,8 +158,8 @@ const registerJavaScriptProviders = (disposables: Disposable[]) =>
     workspace.getConfiguration()
         .get<string[]>(Configuration.JavaScriptLanguages)
         ?.forEach((extension) => {
-            disposables.push(registerCompletionProvider(extension, /className=["|']([\w- ]*$)/));
-            disposables.push(registerCompletionProvider(extension, /class=["|']([\w- ]*$)/));
+            disposables.push(registerCompletionProvider(extension, /className=(?:{?"|{?')([\w- ]*$)/));
+            disposables.push(registerCompletionProvider(extension, /class=(?:{?"|{?')([\w- ]*$)/));
         });
 
 function registerEmmetProviders(disposables: Disposable[]) {


### PR DESCRIPTION
This PR partially addresses https://github.com/zignd/HTML-CSS-Class-Completion/issues/287 by updating the regex that matches for JS(X)/TS(X) files.

The regex uses a non-capturing group `(?:` to match an optional opening curly bracket before a single or double quote to trigger auto-completion. [Matches the following](https://regexr.com/6a2d3):
```
className="...
className='...
className={"...
className={'...
class="...
class='...
class={"...
class={'...
```

